### PR TITLE
Add shadow and corner radius to dropdown tableview.

### DIFF
--- a/CustomDropDown.xcodeproj/project.pbxproj
+++ b/CustomDropDown.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		172E2CB6254254A5001F37B7 /* DropDownMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 172E2CB5254254A5001F37B7 /* DropDownMode.swift */; };
 		172E2CBF25425537001F37B7 /* CustomDropDownDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 172E2CBE25425537001F37B7 /* CustomDropDownDataSource.swift */; };
 		172E2CC32542556A001F37B7 /* CustomDropDownDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 172E2CC22542556A001F37B7 /* CustomDropDownDelegate.swift */; };
+		3D469C3D2545DDFB00B2993A /* ShadowAndCornerConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D469C3C2545DDFB00B2993A /* ShadowAndCornerConfig.swift */; };
 		600DFEAB2529BA4200206E64 /* CustomDropDown.swift in Sources */ = {isa = PBXBuildFile; fileRef = 600DFEAA2529BA4200206E64 /* CustomDropDown.swift */; platformFilter = ios; };
 		6055FCBC2529AEC80096A0FD /* CustomDropDown.h in Headers */ = {isa = PBXBuildFile; fileRef = 6055FCBA2529AEC80096A0FD /* CustomDropDown.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		6055FCDA2529BF290096A0FD /* CustomDropDownPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6055FCD92529BF290096A0FD /* CustomDropDownPresenter.swift */; platformFilter = ios; };
@@ -40,6 +41,7 @@
 		172E2CB5254254A5001F37B7 /* DropDownMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DropDownMode.swift; sourceTree = "<group>"; };
 		172E2CBE25425537001F37B7 /* CustomDropDownDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomDropDownDataSource.swift; sourceTree = "<group>"; };
 		172E2CC22542556A001F37B7 /* CustomDropDownDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomDropDownDelegate.swift; sourceTree = "<group>"; };
+		3D469C3C2545DDFB00B2993A /* ShadowAndCornerConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShadowAndCornerConfig.swift; sourceTree = "<group>"; };
 		600DFEAA2529BA4200206E64 /* CustomDropDown.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomDropDown.swift; sourceTree = "<group>"; };
 		6055FCB72529AEC80096A0FD /* CustomDropDown.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = CustomDropDown.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		6055FCBA2529AEC80096A0FD /* CustomDropDown.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CustomDropDown.h; sourceTree = "<group>"; };
@@ -89,6 +91,7 @@
 				172E2CB125425475001F37B7 /* DropDownConfig.swift */,
 				172E2CB5254254A5001F37B7 /* DropDownMode.swift */,
 				172E2CA225425123001F37B7 /* ImageLabelData.swift */,
+				3D469C3C2545DDFB00B2993A /* ShadowAndCornerConfig.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -307,6 +310,7 @@
 				172E2C8A25423DD3001F37B7 /* ViewCode.swift in Sources */,
 				172E2CC32542556A001F37B7 /* CustomDropDownDelegate.swift in Sources */,
 				172E2CBF25425537001F37B7 /* CustomDropDownDataSource.swift in Sources */,
+				3D469C3D2545DDFB00B2993A /* ShadowAndCornerConfig.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/CustomDropDown/Model/DropDownConfig.swift
+++ b/CustomDropDown/Model/DropDownConfig.swift
@@ -14,11 +14,7 @@ public struct DropDownConfig {
     public var selectedLabelTag: Int = 9999
     public var dropDownLeftRightPadding: UIEdgeInsets = UIEdgeInsets(top: 10, left: 10, bottom: 0, right: 10)
     public var dropDownMode: DropDownMode = .label
-    public var dropDownShadowColor: CGColor = UIColor.black.cgColor
-    public var dropDownShadowOffset: CGSize = .zero
-    public var dropDownShadowOpacity: Float = 0
-    public var dropDownShadowRadius: CGFloat = 0
-    public var dropDownCornerRadius: CGFloat = 0
+    public var shadowAndCornerConfig: ShadowAndCornerConfig = ShadowAndCornerConfig()
     
     public init() {}
 }

--- a/CustomDropDown/Model/DropDownConfig.swift
+++ b/CustomDropDown/Model/DropDownConfig.swift
@@ -14,6 +14,11 @@ public struct DropDownConfig {
     public var selectedLabelTag: Int = 9999
     public var dropDownLeftRightPadding: UIEdgeInsets = UIEdgeInsets(top: 10, left: 10, bottom: 0, right: 10)
     public var dropDownMode: DropDownMode = .label
+    public var dropDownShadowColor: CGColor = UIColor.black.cgColor
+    public var dropDownShadowOffset: CGSize = .zero
+    public var dropDownShadowOpacity: Float = 0
+    public var dropDownShadowRadius: CGFloat = 0
+    public var dropDownCornerRadius: CGFloat = 0
     
     public init() {}
 }

--- a/CustomDropDown/Model/ShadowAndCornerConfig.swift
+++ b/CustomDropDown/Model/ShadowAndCornerConfig.swift
@@ -1,0 +1,19 @@
+//
+//  ShadowAndCornerConfig.swift
+//  CustomDropDown
+//
+//  Created by Guilherme Andrade on 10/25/20.
+//  Copyright © 2020 Amirthy Tejeshwar. All rights reserved.
+//
+
+import UIKit
+
+public struct ShadowAndCornerConfig {
+    public var shadowColor: CGColor = UIColor.black.cgColor
+    public var shadowOffset: CGSize = .zero
+    public var shadowOpacity: Float = 0
+    public var shadowRadius: CGFloat = 0
+    public var cornerRadius: CGFloat = 0
+    
+    public init() {}
+}

--- a/CustomDropDown/View/CustomDropDown.swift
+++ b/CustomDropDown/View/CustomDropDown.swift
@@ -12,6 +12,15 @@ class CustomDropDown<T>: UIView {
     
     // MARK: - Variables
     
+    public var cornerRadius: CGFloat = 0.0 {
+        didSet{
+            containerView.layer.cornerRadius = cornerRadius
+            containerView.layer.masksToBounds = true
+        }
+    }
+    
+    private let containerView = UIView()
+    
     lazy var tableView: UITableView = {
         let view = UITableView()
         view.translatesAutoresizingMaskIntoConstraints = false
@@ -51,13 +60,20 @@ class CustomDropDown<T>: UIView {
 
 extension CustomDropDown: ViewCode {
     func buildViewHierarchy() {
-        addSubview(tableView)
+        addSubview(containerView)
+        containerView.addSubview(tableView)
     }
     
     func setupConstraints() {
-        tableView.topAnchor.constraint(equalTo: topAnchor).isActive = true
-        tableView.bottomAnchor.constraint(equalTo: bottomAnchor).isActive = true
-        tableView.leftAnchor.constraint(equalTo: leftAnchor).isActive = true
-        tableView.rightAnchor.constraint(equalTo: rightAnchor).isActive = true
+        containerView.translatesAutoresizingMaskIntoConstraints = false
+        containerView.leadingAnchor.constraint(equalTo: leadingAnchor).isActive = true
+        containerView.trailingAnchor.constraint(equalTo: trailingAnchor).isActive = true
+        containerView.topAnchor.constraint(equalTo: topAnchor).isActive = true
+        containerView.bottomAnchor.constraint(equalTo: bottomAnchor).isActive = true
+        
+        tableView.topAnchor.constraint(equalTo: containerView.topAnchor).isActive = true
+        tableView.bottomAnchor.constraint(equalTo: containerView.bottomAnchor).isActive = true
+        tableView.leftAnchor.constraint(equalTo: containerView.leftAnchor).isActive = true
+        tableView.rightAnchor.constraint(equalTo: containerView.rightAnchor).isActive = true
     }
 }

--- a/CustomDropDown/View/CustomDropDown.swift
+++ b/CustomDropDown/View/CustomDropDown.swift
@@ -12,17 +12,15 @@ class CustomDropDown<T>: UIView {
     
     // MARK: - Variables
     
-    public var cornerRadius: CGFloat = 0.0 {
+    // Making the view's masksToBounds = true to have round corners prevent the shadow to appear. So, it is necessary to
+    // use the tableview's cornerRadius instead. This way, the shadow can be applied to the view while the
+    // round corners are applied to the tableview.
+    var cornerRadius: CGFloat = 0.0 {
         didSet{
-            containerView.layer.cornerRadius = cornerRadius
-            containerView.layer.masksToBounds = true
+            tableView.layer.cornerRadius = cornerRadius
+            tableView.layer.masksToBounds = true
         }
     }
-    
-    // Making `masksToBounds = true` to have round corners prevent the shadow to appear. So, it was necessary to
-    // wrap the tableview in a containerView. This way, the shadow can be applied to the view while the
-    // round corners are applied to the containerView.
-    private let containerView = UIView()
     
     lazy var tableView: UITableView = {
         let view = UITableView()
@@ -63,20 +61,13 @@ class CustomDropDown<T>: UIView {
 
 extension CustomDropDown: ViewCode {
     func buildViewHierarchy() {
-        addSubview(containerView)
-        containerView.addSubview(tableView)
+        addSubview(tableView)
     }
     
     func setupConstraints() {
-        containerView.translatesAutoresizingMaskIntoConstraints = false
-        containerView.leadingAnchor.constraint(equalTo: leadingAnchor).isActive = true
-        containerView.trailingAnchor.constraint(equalTo: trailingAnchor).isActive = true
-        containerView.topAnchor.constraint(equalTo: topAnchor).isActive = true
-        containerView.bottomAnchor.constraint(equalTo: bottomAnchor).isActive = true
-        
-        tableView.topAnchor.constraint(equalTo: containerView.topAnchor).isActive = true
-        tableView.bottomAnchor.constraint(equalTo: containerView.bottomAnchor).isActive = true
-        tableView.leftAnchor.constraint(equalTo: containerView.leftAnchor).isActive = true
-        tableView.rightAnchor.constraint(equalTo: containerView.rightAnchor).isActive = true
+        tableView.topAnchor.constraint(equalTo: topAnchor).isActive = true
+        tableView.bottomAnchor.constraint(equalTo: bottomAnchor).isActive = true
+        tableView.leftAnchor.constraint(equalTo: leftAnchor).isActive = true
+        tableView.rightAnchor.constraint(equalTo: rightAnchor).isActive = true
     }
 }

--- a/CustomDropDown/View/CustomDropDown.swift
+++ b/CustomDropDown/View/CustomDropDown.swift
@@ -19,6 +19,9 @@ class CustomDropDown<T>: UIView {
         }
     }
     
+    // Making `masksToBounds = true` to have round corners prevent the shadow to appear. So, it was necessary to
+    // wrap the tableview in a containerView. This way, the shadow can be applied to the view while the
+    // round corners are applied to the containerView.
     private let containerView = UIView()
     
     lazy var tableView: UITableView = {

--- a/CustomDropDown/View/CustomDropDownView.swift
+++ b/CustomDropDown/View/CustomDropDownView.swift
@@ -92,12 +92,12 @@ class CustomDropDownView<T>: UIView, UITableViewDataSource, UITableViewDelegate 
         dropDown = CustomDropDown<T>(dropDownView: self, tag: config.dropDownTag)
         dropDown?.translatesAutoresizingMaskIntoConstraints = false
 
-        dropDown?.cornerRadius = config.dropDownCornerRadius
+        dropDown?.cornerRadius = config.shadowAndCornerConfig.cornerRadius
         
-        dropDown?.layer.shadowColor = config.dropDownShadowColor
-        dropDown?.layer.shadowOpacity = config.dropDownShadowOpacity
-        dropDown?.layer.shadowOffset = config.dropDownShadowOffset
-        dropDown?.layer.shadowRadius = config.dropDownShadowRadius
+        dropDown?.layer.shadowColor = config.shadowAndCornerConfig.shadowColor
+        dropDown?.layer.shadowOpacity = config.shadowAndCornerConfig.shadowOpacity
+        dropDown?.layer.shadowOffset = config.shadowAndCornerConfig.shadowOffset
+        dropDown?.layer.shadowRadius = config.shadowAndCornerConfig.shadowRadius
     }
     
     private func resetDropDownConstraints() {

--- a/CustomDropDown/View/CustomDropDownView.swift
+++ b/CustomDropDown/View/CustomDropDownView.swift
@@ -91,6 +91,13 @@ class CustomDropDownView<T>: UIView, UITableViewDataSource, UITableViewDelegate 
     private func setupDropDown() {
         dropDown = CustomDropDown<T>(dropDownView: self, tag: config.dropDownTag)
         dropDown?.translatesAutoresizingMaskIntoConstraints = false
+
+        dropDown?.cornerRadius = config.dropDownCornerRadius
+        
+        dropDown?.layer.shadowColor = config.dropDownShadowColor
+        dropDown?.layer.shadowOpacity = config.dropDownShadowOpacity
+        dropDown?.layer.shadowOffset = config.dropDownShadowOffset
+        dropDown?.layer.shadowRadius = config.dropDownShadowRadius
     }
     
     private func resetDropDownConstraints() {

--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -49,6 +49,15 @@ extension ViewController: CustomDropDownDelegate, CustomDropDownDataSource {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath, data: Any, identifier: Int) {
         
     }
+    
+    func config(identifier: Int) -> DropDownConfig {
+        var config = DropDownConfig()
+        config.dropDownShadowOffset = CGSize(width: 5, height: 5)
+        config.dropDownShadowOpacity = 0.8
+        config.dropDownShadowRadius = 5
+        config.dropDownCornerRadius = 5
+        return config
+    }
 }
 
 extension UIView {

--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -52,10 +52,14 @@ extension ViewController: CustomDropDownDelegate, CustomDropDownDataSource {
     
     func config(identifier: Int) -> DropDownConfig {
         var config = DropDownConfig()
-        config.dropDownShadowOffset = CGSize(width: 5, height: 5)
-        config.dropDownShadowOpacity = 0.8
-        config.dropDownShadowRadius = 5
-        config.dropDownCornerRadius = 5
+        
+        var shadowAndCornerConfig = ShadowAndCornerConfig()
+        shadowAndCornerConfig.shadowOffset = CGSize(width: 5, height: 5)
+        shadowAndCornerConfig.shadowOpacity = 0.8
+        shadowAndCornerConfig.shadowRadius = 5
+        shadowAndCornerConfig.cornerRadius = 5
+        
+        config.shadowAndCornerConfig = shadowAndCornerConfig
         return config
     }
 }


### PR DESCRIPTION
# Description

Added corner radius and shadow to the dropdown table. It's possible for the user to configure the parameters of the features in the `DropDownConfig` struct. The default configuration have both of the features disabled.

This is how it looks on the example project with the following parameters
```swift
dropDownShadowOffset = CGSize(width: 5, height: 5)
dropDownShadowOpacity = 0.8
dropDownShadowRadius = 5
dropDownCornerRadius = 5
```
![Screen Shot 2020-10-25 at 12 10 19 PM](https://user-images.githubusercontent.com/16858827/97112166-87eeb780-16c1-11eb-9c18-02636fb8ffdf.png)


Fixes #20 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

* Xcode: Version 11.5 (11E608c)
* Model name: iPhone 11 Pro Max (13.5)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
